### PR TITLE
docs: fix typo 'rendere' → 'renderer' in system_messages.html

### DIFF
--- a/07/system_messages.html
+++ b/07/system_messages.html
@@ -1270,7 +1270,7 @@
             </pre>
             <br>
             If the client gets this packet. It adds the payload (line) into
-            the console log where the rendere can pick it up if the user
+            the console log where the renderer can pick it up if the user
             opens the rcon console.
             <pre class="code-snippet">
                 <code>


### PR DESCRIPTION
## Summary
Fix typo: `rendere` → `renderer` in `07/system_messages.html` line 1273.

Referenced in issue #35.